### PR TITLE
migrate scoreboard to imgui tables api (1.8+)

### DIFF
--- a/tf2_bot_detector/GameData/IPlayer.cpp
+++ b/tf2_bot_detector/GameData/IPlayer.cpp
@@ -32,3 +32,13 @@ std::string IPlayer::GetNameSafe() const
 {
 	return CollapseNewlines(GetNameUnsafe());
 }
+
+std::string IPlayer::GetNameSafe_NoInvis() const
+{
+	return FilterInvisChars(GetNameSafe());
+}
+
+std::string IPlayer::GetNameAscii() const
+{
+	return FilterUnicode(GetNameSafe());
+}

--- a/tf2_bot_detector/GameData/IPlayer.h
+++ b/tf2_bot_detector/GameData/IPlayer.h
@@ -64,6 +64,10 @@ namespace tf2_bot_detector
 
 		// Player name with evil characters collapsed/removed
 		std::string GetNameSafe() const;
+		// (real) Player name with evil characters collapsed/removed
+		std::string GetNameSafe_NoInvis() const;
+		// Player name with only ascii characters.
+		std::string GetNameAscii() const;
 
 		virtual SteamID GetSteamID() const = 0;
 		virtual const mh::expected<SteamAPI::PlayerSummary>& GetPlayerSummary() const = 0;

--- a/tf2_bot_detector/ModeratorLogic.cpp
+++ b/tf2_bot_detector/ModeratorLogic.cpp
@@ -104,6 +104,11 @@ namespace
 			// same as above, but we don't want to spam party chat.
 			bool m_PartyWarned = false;
 
+			// ignore rules for this player
+			// reason: if you have a hilariously agressive rule and
+			//  don't want to call this person out constantly 
+			bool m_IgnoreRules = false;
+
 			// If we're not the bot leader, prevent this player from triggering
 			// any warnings (but still participates in other warnings!!!)
 			std::optional<time_point_t> m_ConnectingWarningDelayEnd;
@@ -285,6 +290,11 @@ void ModeratorLogic::OnPlayerStatusUpdate(IWorldState& world, const IPlayer& pla
 
 	if (m_Settings->m_AutoMark)
 	{
+		const auto extra_data = player.GetData<PlayerExtraData>();
+		if (extra_data != nullptr && extra_data->m_IgnoreRules) {
+			return;
+		}
+
 		for (const ModerationRule& rule : m_Rules.GetRules())
 		{
 			if (!rule.Match(player))
@@ -339,6 +349,12 @@ void ModeratorLogic::OnChatMsg(IWorldState& world, IPlayer& player, const std::s
 
 	if (m_Settings->m_AutoMark && !botMsgDetected)
 	{
+		// ignore any rule processing for this player.
+		const auto extra_data = player.GetData<PlayerExtraData>();
+		if (extra_data != nullptr && extra_data->m_IgnoreRules) {
+			return;
+		}
+
 		for (const ModerationRule& rule : m_Rules.GetRules())
 		{
 			if (!rule.Match(player, msg))

--- a/tf2_bot_detector/SetupFlow/TF2CommandLinePage.cpp
+++ b/tf2_bot_detector/SetupFlow/TF2CommandLinePage.cpp
@@ -291,6 +291,7 @@ static void OpenTF2(const Settings& settings, const std::string_view& rconPasswo
 	Log("[Linux] new LD_LIBRARY_PATH = {}", new_library_path);
 	setenv("LD_LIBRARY_PATH", new_library_path.c_str(), true);
 	setenv("SteamEnv", "1", true);
+	// TODO: manually set SDL_DYNAMIC_API (see #37)
 #endif
 	Processes::Launch(hl2Path, args);
 #ifdef __linux__

--- a/tf2_bot_detector/UI/ImGui_TF2BotDetector.cpp
+++ b/tf2_bot_detector/UI/ImGui_TF2BotDetector.cpp
@@ -41,7 +41,7 @@ void ImGui::TextRightAligned(const std::string_view& text, float offsetX)
 	const auto textSize = ImGui::CalcTextSize(text.data(), text.data() + text.size());
 
 	float cursorPosX = ImGui::GetCursorPosX();
-	cursorPosX += ImGui::GetColumnWidth();// ImGui::GetContentRegionAvail().x;
+	cursorPosX += ImGui::GetContentRegionAvail().x;
 	cursorPosX -= textSize.x;
 	cursorPosX -= 2 * ImGui::GetStyle().ItemSpacing.x;
 	cursorPosX -= offsetX;

--- a/tf2_bot_detector/UI/MainWindow.Scoreboard.cpp
+++ b/tf2_bot_detector/UI/MainWindow.Scoreboard.cpp
@@ -95,7 +95,15 @@ void MainWindow::OnDrawScoreboard()
 
 			// Real table begins here.
 
-			ImGui::BeginTable("ScoreboardTable", 7, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_Resizable | ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_NoPadInnerX | ImGuiTableFlags_NoPadOuterX);
+			ImGuiTableFlags flags = ImGuiTableFlags_NoSavedSettings |
+				ImGuiTableFlags_Resizable |
+				ImGuiTableFlags_Sortable |
+				ImGuiTableFlags_SizingStretchProp |
+				ImGuiTableFlags_NoPadInnerX |
+				ImGuiTableFlags_NoPadOuterX |
+				ImGuiTableFlags_NoBordersInBody;
+
+			ImGui::BeginTable("ScoreboardTable", 7, flags);
 
 			// Columns setup
 			{
@@ -471,6 +479,23 @@ void MainWindow::OnDrawScoreboardContextMenu(IPlayer& player)
 
 		DrawPlayerContextMarkMenu(player.GetSteamID(), player.GetNameSafe(), data.m_pendingReason);
 
+		/*
+		TODO: get moderatorlogic playerextradata and make a checkbox for m_IgnoreRules
+		if (ImGui::BeginMenu("Misc"))
+		{
+			const auto extra_data = player.GetData<IModeratorLogic>();
+			if (extra_data != nullptr) {
+
+			}
+			else {
+
+				ImGui::Checkbox("");
+			}
+
+
+
+			ImGui::EndMenu();
+		}*/
 #ifdef _DEBUG
 		ImGui::Separator();
 

--- a/tf2_bot_detector/UI/MainWindow.cpp
+++ b/tf2_bot_detector/UI/MainWindow.cpp
@@ -516,6 +516,8 @@ void MainWindow::OnDraw()
 	const auto& mainWindowState = m_Settings.m_UIState.m_MainWindow;
 	const bool columnsEnabled = (mainWindowState.m_ChatEnabled && (mainWindowState.m_AppLogEnabled || mainWindowState.m_ScoreboardEnabled));
 
+	// TODO: make this.... not using the columns api.
+	// for now i am lazy.
 	if (columnsEnabled)
 		ImGui::Columns(2, "MainWindowSplit");
 

--- a/tf2_bot_detector/Util/TextUtils.cpp
+++ b/tf2_bot_detector/Util/TextUtils.cpp
@@ -7,6 +7,7 @@
 
 #include <codecvt>
 #include <fstream>
+#include <set>
 
 using namespace std::string_literals;
 
@@ -159,5 +160,34 @@ std::string tf2_bot_detector::CollapseNewlines(const std::string_view& input)
 		firstLine = false;
 	}
 
+	return retVal;
+}
+
+/*
+const static std::set<std::string> common_invis_chars = {
+	"\u0e3a", // 0xE0 0xB8 0xBA 0x00
+	"\u0e4a", // 0xE0 0xB9 0x8A 0x00
+	"\u0e47", // 0xE0 0xB9 0x87 0x00
+	"\u0e48", // 0xE0 0xB9 0x87 0x00
+};*/
+
+// TODO
+std::string tf2_bot_detector::FilterInvisChars(const std::string_view& input)
+{
+	std::string retVal = std::string(input);
+
+
+	return retVal;
+}
+
+bool is_not_unicode(char c)
+{
+	return !(c >= 0 && c < 128);
+}
+
+std::string tf2_bot_detector::FilterUnicode(const std::string_view& input)
+{
+	std::string retVal = std::string(input);
+	retVal.erase(std::remove_if(retVal.begin(), retVal.end(), is_not_unicode), retVal.end());
 	return retVal;
 }

--- a/tf2_bot_detector/Util/TextUtils.h
+++ b/tf2_bot_detector/Util/TextUtils.h
@@ -22,4 +22,6 @@ namespace tf2_bot_detector
 	void WriteWideFile(const std::filesystem::path& filename, const std::u16string_view& text);
 
 	std::string CollapseNewlines(const std::string_view& input);
+	std::string FilterInvisChars(const std::string_view& input);
+	std::string FilterUnicode(const std::string_view& input);
 }


### PR DESCRIPTION
bumping to something that is supported and receives bugfixes and features   
\+ and Ability to sort playerlist however you like as a treat, i guess

![bd-tables](https://github.com/user-attachments/assets/b1fe301b-8b22-49f3-b4b9-959f0ae1f11f)   

## Regressions
scoreboard won't grow over and "take over" the logs window.   
honestly I might just keep that behavior. if you want to not see logs window just go to view -> uncheck logs window.

## Limitations 
I only migrated scoreboard there are some things that use the old column api but later lazy 

## Other Notes
may fix #24
we can now start working on #27 (just have an option to disable the sorting if mouseover)
